### PR TITLE
fix vertx registering handlers

### DIFF
--- a/rlpx/src/main/java/org/apache/tuweni/rlpx/vertx/VertxRLPxService.java
+++ b/rlpx/src/main/java/org/apache/tuweni/rlpx/vertx/VertxRLPxService.java
@@ -230,7 +230,7 @@ public final class VertxRLPxService implements RLPxService {
               new NetClientOptions()
                   .setTcpKeepAlive(true)
                   .setConnectTimeout(connectTimeout)
-                  .setIdleTimeout(idleTimeout));
+                  .setIdleTimeout(idleTimeout).setRegisterWriteHandler(true));
       server =
           vertx
               .createNetServer(
@@ -238,7 +238,7 @@ public final class VertxRLPxService implements RLPxService {
                       .setPort(listenPort)
                       .setHost(networkInterface)
                       .setTcpKeepAlive(true)
-                      .setIdleTimeout(idleTimeout))
+                      .setIdleTimeout(idleTimeout).setRegisterWriteHandler(true))
               .connectHandler(this::receiveMessage);
       CompletableAsyncCompletion complete = AsyncCompletion.incomplete();
       server.listen(

--- a/rlpx/src/main/java/org/apache/tuweni/rlpx/vertx/VertxRLPxService.java
+++ b/rlpx/src/main/java/org/apache/tuweni/rlpx/vertx/VertxRLPxService.java
@@ -230,7 +230,8 @@ public final class VertxRLPxService implements RLPxService {
               new NetClientOptions()
                   .setTcpKeepAlive(true)
                   .setConnectTimeout(connectTimeout)
-                  .setIdleTimeout(idleTimeout).setRegisterWriteHandler(true));
+                  .setIdleTimeout(idleTimeout)
+                  .setRegisterWriteHandler(true));
       server =
           vertx
               .createNetServer(
@@ -238,7 +239,8 @@ public final class VertxRLPxService implements RLPxService {
                       .setPort(listenPort)
                       .setHost(networkInterface)
                       .setTcpKeepAlive(true)
-                      .setIdleTimeout(idleTimeout).setRegisterWriteHandler(true))
+                      .setIdleTimeout(idleTimeout)
+                      .setRegisterWriteHandler(true))
               .connectHandler(this::receiveMessage);
       CompletableAsyncCompletion complete = AsyncCompletion.incomplete();
       server.listen(


### PR DESCRIPTION
## PR description
Fixes a regression seen with Vert.x upgrade, where the registration of handlers is no longer on by default.
