### PR TITLE
change log level for dns querry warning

### DIFF
--- a/dns-discovery/src/main/kotlin/org/apache/tuweni/discovery/DNSResolver.kt
+++ b/dns-discovery/src/main/kotlin/org/apache/tuweni/discovery/DNSResolver.kt
@@ -153,7 +153,7 @@ class DNSResolver @JvmOverloads constructor(
         return null
       }
     } catch (e: DnsException) {
-      logger.warn("DNS query error with $domainName", e)
+      logger.debug("DNS query error with $domainName", e)
       return null
     } catch (e: IOException) {
       logger.warn("I/O exception contacting remote DNS server when resolving $domainName", e)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/tmio/tuweni/blob/main/CONTRIBUTING.md -->

## PR description

I suggest changing the DNS error log level to debug as this log is causing a lot of spam and alarming many users who think it's a serious error when it's not that severe. I believe it would be preferable to set it to debug so we are not spammed with this log at the info level.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
